### PR TITLE
Tc dev

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,18 @@ if you're finding they're more hassle than you'd like!
 Documentation for our current hooks are available on the left hand side of
 this page.
 
+example configuration:
+
+.. code-block:: yaml
+  :caption: .pre-commit-config.yaml
+
+  repos:
+      - repo: https://github.com/stfc/pre-commit-hooks
+        rev: v0.3.0
+        hooks:
+          - id: check-mypy-import-errors
+          - id: check-pylint-import-errors
+
 TODO: add a worked example of creating a new hook
 
 TODO: add instructions on how to use these hooks within pre-commit-config.yaml

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,7 @@ example configuration:
 
   repos:
       - repo: https://github.com/stfc/pre-commit-hooks
-        rev: v0.3.0
+        rev: v0.3.1
         hooks:
           - id: check-mypy-import-errors
           - id: check-pylint-import-errors

--- a/hooks/check_missing_requirements.py
+++ b/hooks/check_missing_requirements.py
@@ -1,5 +1,5 @@
 """Checks to see if the package requirements are all present in the current
-environment.
+python environment.
 """
 import subprocess
 import sys

--- a/hooks/check_mypy_import_errors.py
+++ b/hooks/check_mypy_import_errors.py
@@ -1,4 +1,4 @@
-"""Check and prevent mypy import errors."""
+"""Check and prevent mypy errors due to missing stubs."""
 import sys
 import warnings
 from typing import Optional
@@ -28,6 +28,9 @@ warnings.showwarning = _warning
 class CheckMypyImportErrors(Hook):  # pylint: disable=too-few-public-methods
     """Hook to check whether mypy will raise import errors using the current
     project configuration, and fix the config file if necessary.
+
+    This is configured to only run when changes to your `requirements.txt` or
+    `pyproject.toml` file are staged.
     """
 
     def run(self) -> int:
@@ -84,7 +87,7 @@ class CheckMypyImportErrors(Hook):  # pylint: disable=too-few-public-methods
 
         print(
             "  import errors found!\n",
-            f"  adding new exceptions to setup.cfg: {', '.join(bad_imports)}",
+            f"  adding new exceptions to config file: {', '.join(bad_imports)}",
         )
         setup_file.add_mypy_ignore(bad_imports)
         setup_file.save_to_disk()

--- a/hooks/check_pylint_import_errors.py
+++ b/hooks/check_pylint_import_errors.py
@@ -13,19 +13,21 @@ from .utils.config_file import ConfigFile
 class CheckPylintImportErrors(Hook):  # pylint: disable=too-few-public-methods
     """Hook to check whether pylint will raise import errors using the current
     project configuration, and fix the config file if necessary.
+
+    This is configured to only run when changes to your `requirements.txt` or
+    `pyproject.toml` file are staged.
     """
 
     def run(self) -> int:
         """
-        Fixes pylint parameters in ``setup.cfg`` to prevent the CI pipeline giving
-        import errors during linting jobs, as not all packages provide pylint
-        support. This function should be run from within the top level repo
-        directory.
+        Fixes pylint parameters to prevent the CI pipeline giving import errors
+        during linting jobs, as not all packages provide pylint support. This
+        function should be run from within the top level repo directory.
 
         The function applies pylint to this repo, and greps the resultant output
         for any import error (E0401) messages. The function will then append
-        the bad package/module names to the ``[pylint]`` section of ``setup.cfg``
-        to silence the error in future.
+        the bad package/module names to the relevant config section to silence
+        the error in future.
 
         This is a known bug with pylint and in this case, silencing the errors
         is the only fix to prevent CI job failure.
@@ -75,7 +77,7 @@ class CheckPylintImportErrors(Hook):  # pylint: disable=too-few-public-methods
 
         print(
             "  Pylint import errors found!\n",
-            f"  adding new exceptions to setup.cfg: {', '.join(bad_imports)}",
+            f"  adding new exceptions to config file: {', '.join(bad_imports)}",
         )
 
         # add bad modules to the pylint ignore section:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "hooks"
-version = "0.3.0"
+version = "0.3.1"
 description = "Custom pre-commit hooks for use within our projects"
 authors = [ "Tom Collingwood <tom.collingwood@stfc.ac.uk>",]
 license = "MIT"


### PR DESCRIPTION
- remove hard-coded references to setup.cfg (since this also works with pyproject.toml)
- add example usage to docs